### PR TITLE
Reconfigured task locking mechanism to use Django cache instead of Redis

### DIFF
--- a/cdr_stats/cdr/task_lock.py
+++ b/cdr_stats/cdr/task_lock.py
@@ -1,0 +1,35 @@
+#code from http://loose-bits.com/2010/10/distributed-task-locking-in-celery.html merged with
+#code merged with http://ask.github.com/celery/cookbook/tasks.html
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.log import getLogger
+
+def only_one(function=None, key="", timeout=None):
+    """Enforce only one celery task at a time."""
+    def _dec(run_func):
+        """Decorator."""
+
+        def _caller(*args, **kwargs):
+            """Caller."""
+	    logger = getLogger(**kwargs)
+            ret_value = None
+	    # cache.add fails if if the key already exists
+	    # memcache delete is very slow, but we have to use it to take
+	    # advantage of using add() for atomic locking
+    	    have_lock = lambda: cache.add(key, "true", timeout)
+    	    release_lock = lambda: cache.delete(key)
+            try:
+                if have_lock():
+            	    logger.debug("Lock aquired for task : %s" % key)
+                    ret_value = run_func(*args, **kwargs)
+            finally:
+                if have_lock():
+                    release_lock()
+            	    logger.debug("Lock released for task : %s" % key)
+
+            return ret_value
+
+        return _caller
+
+    return _dec(function) if function is not None else _dec


### PR DESCRIPTION
Hello,

Here is quick patch to use Django cache instead of exclusively using Redis MQ for task locking mechanism.
This fixes issues when other backends are used instead of Redis. Please test the code then accept into main GIT tree.

Kind regards,
Arunas
