### PR TITLE
internal db for freeswitch can now be changed to postgresql

### DIFF
--- a/cdr_stats/cdr/import_cdr_freeswitch_mongodb.py
+++ b/cdr_stats/cdr/import_cdr_freeswitch_mongodb.py
@@ -119,12 +119,19 @@ def get_element(cdr):
         write_codec = cdr['variables']['write_codec']
     else:
         write_codec = ''
+    # Get callee_id_name
+    if 'variables' in cdr and 'callee_id_name' in cdr['variables']:
+        callee_id_name = cdr['variables']['callee_id_name'].lstrip()
+    else:
+        callee_id_name = ''
+
 
     data_element = {
         'accountcode': accountcode,
         'remote_media_ip': remote_media_ip,
         'caller_id_number': caller_id_number,
         'caller_id_name': caller_id_name,
+        'callee_id_name': callee_id_name,
         'duration': duration,
         'billsec': billsec,
         'direction': direction,
@@ -227,7 +234,7 @@ def create_monthly_analytic(daily_date, start_uepoch, switch_id,
 
 
 def generate_global_cdr_record(switch_id, caller_id_number, caller_id_name, destination_number,
-                               duration, billsec, hangup_cause_id, accountcode, direction,
+                               callee_id_name, duration, billsec, hangup_cause_id, accountcode, direction,
                                uuid, remote_media_ip, start_uepoch, answer_uepoch, end_uepoch,
                                mduration, billmsec, read_codec, write_codec, cdr_type,
                                cdr_object_id, country_id, authorized):
@@ -239,6 +246,7 @@ def generate_global_cdr_record(switch_id, caller_id_number, caller_id_name, dest
         'caller_id_number': caller_id_number,
         'caller_id_name': caller_id_name,
         'destination_number': destination_number,
+        'callee_id_name': callee_id_name,
         'duration': duration,
         'billsec': billsec,
         'hangup_cause_id': hangup_cause_id,
@@ -322,6 +330,7 @@ def func_importcdr_aggregate(shell, importcdr_handler, switch, ipaddress):
             "variables.billmsec": 1,
             "variables.read_codec": 1,
             "variables.write_codec": 1,
+            "variables.callee_id_name": 1,
             "import_cdr_monthly": 1,
             "import_cdr_daily": 1,
             "import_cdr_hourly": 1,
@@ -372,10 +381,11 @@ def func_importcdr_aggregate(shell, importcdr_handler, switch, ipaddress):
         billmsec = data_element['billmsec']
         read_codec = data_element['read_codec']
         write_codec = data_element['write_codec']
+        callee_id_name = data_element['callee_id_name']
 
         # Prepare global CDR
         cdr_record = generate_global_cdr_record(switch.id, caller_id_number,
-            caller_id_name, destination_number, duration, billsec, hangup_cause_id,
+            caller_id_name, destination_number, callee_id_name, duration, billsec, hangup_cause_id,
             accountcode, direction, uuid, remote_media_ip, start_uepoch, answer_uepoch,
             end_uepoch, mduration, billmsec, read_codec, write_codec,
             CDR_TYPE["freeswitch"], cdr['_id'], country_id, authorized)

--- a/cdr_stats/templates/frontend/cdr_view.html
+++ b/cdr_stats/templates/frontend/cdr_view.html
@@ -262,7 +262,13 @@
                     {% endif %}
                     {{ row.caller_id_name }}
                 </td>
-                <td>{{ row.destination_number }}</td>
+                <td>
+                    {{ row.destination_number }}
+                    {% if row.destination_number and row.callee_id_name %}
+                       -
+                    {% endif %}
+                    {{ row.callee_id_name }}
+                </td>
                 <td>{% if result == 1 %}
                         {{ row.duration|conv_min }}
                     {% else %}


### PR DESCRIPTION
config example:
settings_local.py
CDR_BACKEND = {
'127.0.0.1': {
'db_engine': 'mongodb', # mysql, pgsql, mongodb
'cdr_type': 'freeswitch', # asterisk or freeswitch
'db_name': 'freeswitch_cdr',
'table_name': 'cdr', # collection if mongodb
'host': 'localhost',
'port': 27017, # 3306 mysql, 5432 pgsql, 27017 mongodb
'user': '',
'password': '',
'internal_db_engine': 'pgsql', # pgsql or sqlite(default)
'internal_db_name': 'freeswitch',
'internal_db_host': 'localhost',
'internal_db_port': '5432',
'internal_db_user': 'freeswitch',
'internal_db_password': 'freeswitch',
},
}