### PR TITLE
fix django-debug-toolbar dependency

### DIFF
--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -18,7 +18,7 @@ git+http://github.com/Star2Billing/django-notification
 django-frontend-notification==0.3.2
 django-genericadmin==0.6.1
 django-nvd3==0.8.2
-django-debug-toolbar
+django-debug-toolbar==1.4
 django-lets-go==2.9.3
 django-extensions==1.6.7
 django-bower==5.0.4


### PR DESCRIPTION
Last version of Django Debug Toolbar, version 1.5, requires Django >= 1.8 and forces the update of Django from 1.7.7 to 1.10 breaking the install script.